### PR TITLE
#fixes install requirements

### DIFF
--- a/.github/workflows/quality_assurance.yml
+++ b/.github/workflows/quality_assurance.yml
@@ -2,9 +2,9 @@ name: Quality Assurance
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, synchronize, reopened]
   schedule:
     - cron: 0 16 * * *

--- a/.requirements/base.txt
+++ b/.requirements/base.txt
@@ -1,5 +1,6 @@
-Django>=3.2
+Django>=3.2,<4.3
 django-axis-order==0.1.0
 eulxml==1.1.3
 isodate==0.6.1
 camel-converter==3.0.0
+requests>=2.23.0,<2.30.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[v0.1.1] - 2023-05-15
+---------------------
+
+Fixes
+~~~~~
+
+* pip install requirements by adding the requirements from .requirements/base.txt
+
 [v0.1.0] - 2023-05-15
--------------------------
+---------------------
 
 Added
 ~~~~~
@@ -16,5 +24,6 @@ Added
 * xml mapper classes for wms v1.1.1, wfs v2.0.0, csw v2.0.2 capabilities
 * xml mapper classes for wfs v2.0.0 get feature request
 
-[unreleased]: https://github.com/mrmap-community/django-ows-lib/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/mrmap-community/django-ows-lib/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/mrmap-community/django-ows-lib/releases/tag/v0.1.0
 [0.1.0]: https://github.com/mrmap-community/django-ows-lib/releases/tag/v0.1.0

--- a/ows_lib/__init__.py
+++ b/ows_lib/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 VERSION = __version__  # synonym

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ REQUIREMENTS = [
     "django-axis-order==0.1.0",
     "eulxml==1.1.3",
     "isodate==0.6.1",
-    "camel-converter==3.0.0"
+    "camel-converter==3.0.0",
+    "requests>=2.23.0,<2.30.0"
 ]
 
 with open("README.rst", "r", encoding="utf-8") as fh:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from pkg_resources import parse_requirements
 from setuptools import find_namespace_packages, setup
 
 name = 'django-ows-lib'
@@ -10,6 +11,10 @@ url = 'https://github.com/mrmap-community/django-ows-lib'
 author = 'mrmap-community'
 author_email = 'jonas.kiefer@live.com'
 license = 'MIT'
+
+
+install_reqs = parse_requirements(".requirements/base.txt")
+reqs = [str(ir.req) for ir in install_reqs]
 
 
 with open("README.rst", "r", encoding="utf-8") as fh:
@@ -40,9 +45,7 @@ setup(
     packages=[p for p in find_namespace_packages(
         exclude=('tests*',)) if p.startswith(package)],
     include_package_data=True,
-    install_requires=[
-        "django>=3.0,<4.3",
-    ],
+    install_requires=reqs,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 import re
 
-from pkg_resources import parse_requirements
 from setuptools import find_namespace_packages, setup
 
 name = 'django-ows-lib'
@@ -13,8 +12,8 @@ author_email = 'jonas.kiefer@live.com'
 license = 'MIT'
 
 
-install_reqs = parse_requirements(".requirements/base.txt")
-reqs = [str(ir.req) for ir in install_reqs]
+with open('.requirements/base.txt') as f:
+    required = f.read().splitlines()
 
 
 with open("README.rst", "r", encoding="utf-8") as fh:
@@ -45,7 +44,7 @@ setup(
     packages=[p for p in find_namespace_packages(
         exclude=('tests*',)) if p.startswith(package)],
     include_package_data=True,
-    install_requires=reqs,
+    install_requires=required,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,13 @@ author_email = 'jonas.kiefer@live.com'
 license = 'MIT'
 
 
-with open('.requirements/base.txt') as f:
-    required = f.read().splitlines()
-
+REQUIREMENTS = [
+    "django>=3.0,<4.3",
+    "django-axis-order==0.1.0",
+    "eulxml==1.1.3",
+    "isodate==0.6.1",
+    "camel-converter==3.0.0"
+]
 
 with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -44,7 +48,7 @@ setup(
     packages=[p for p in find_namespace_packages(
         exclude=('tests*',)) if p.startswith(package)],
     include_package_data=True,
-    install_requires=required,
+    install_requires=REQUIREMENTS,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectName=django-ows-lib
 sonar.projectKey=mrmap-community_django-ows-lib
 sonar.organization=mrmap-community
-sonar.projectVersion=v0.1.0
+sonar.projectVersion=v0.1.1
 
 # Path to sources
 sonar.sources=./ows_lib

--- a/tox.ini
+++ b/tox.ini
@@ -18,11 +18,6 @@ deps=
     requests227: requests>=2.27.0,<2.28.0
     requests228: requests>=2.28.0,<2.29.0
     requests229: requests>=2.29.0,<2.30.0
-    django-axis-order==0.1.0
-    eulxml==1.1.3
-    isodate==0.6.1
-    camel-converter==3.0.0
-    coverage==7.2.5
 
 setenv =
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,11 @@ deps=
     requests227: requests>=2.27.0,<2.28.0
     requests228: requests>=2.28.0,<2.29.0
     requests229: requests>=2.29.0,<2.30.0
+    django-axis-order==0.1.0
+    eulxml==1.1.3
+    isodate==0.6.1
+    camel-converter==3.0.0
+    coverage==7.2.5
 
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
If this package was successfully installed and used the following error will raise on runtime:
ModuleNotFoundError: No module named 'camel_converter'

Caused by missing install requirements on setup.py